### PR TITLE
bug fix: slight change of template on Piwigo 2.10

### DIFF
--- a/210x.pattern.php
+++ b/210x.pattern.php
@@ -14,8 +14,8 @@ $pattern['OS_default_prefilter_index']['R']['table_content_begin']='<div id="con
 ';
 $pattern['OS_default_prefilter_index']['S']['div_titrePage_deletion']='</div>{* <!-- titrePage --> *}';
 $pattern['OS_default_prefilter_index']['R']['div_titrePage_deletion']='';
-$pattern['OS_default_prefilter_index']['S']['div_titrePage_embed']='<h2>{$TITLE}</h2>';
-$pattern['OS_default_prefilter_index']['R']['div_titrePage_embed']='<h2>{$TITLE}</h2>
+$pattern['OS_default_prefilter_index']['S']['div_titrePage_embed']='<h2>{$TITLE} {if $NB_ITEMS > 0}<span class="badge nb_items">{$NB_ITEMS}</span>{/if}</h2>';
+$pattern['OS_default_prefilter_index']['R']['div_titrePage_embed']='<h2>{$TITLE} {if $NB_ITEMS > 0}<span class="badge nb_items">{$NB_ITEMS}</span>{/if}</h2>
 	</div>{* <!-- titrePage --> *}  
 	  </td>
       <td id="section_up_right">&nbsp;</td>


### PR DESCRIPTION
A small change on Piwigo 2.10 template makes the pattern not match in your prefilter.